### PR TITLE
Adds control for miner and support for multiple transactions

### DIFF
--- a/api/eth.js
+++ b/api/eth.js
@@ -160,7 +160,8 @@ module.exports = function(services) {
           value: { type: 'number', defaultVal: new BigNumber(0) },
           data: { type: 'hex', defaultVal: null },
           nonce: { type: 'number', defaultVal: null },
-          contract: { type: 'contract', defaultVal: null }
+          contract: { type: 'contract', defaultVal: null },
+          delayed: {type: 'bool', defaultVal: false }
         }
       }],
       handler: function(options, cb) {

--- a/api/sandbox.js
+++ b/api/sandbox.js
@@ -168,6 +168,20 @@ module.exports = function(services) {
       handler: function(cb) {
         cb(null, sandbox.projectName);
       }
+    },
+    pauseMiner: {
+      args: [],
+      handler: function (cb) {
+        sandbox.pauseMiner = true;
+        cb();
+      }
+    },
+    resumeMiner: {
+      args: [],
+      handler: function (cb) {
+        sandbox.pauseMiner = false;
+        cb();
+      }
     }
   };
 };

--- a/sandbox/sandbox.js
+++ b/sandbox/sandbox.js
@@ -59,6 +59,7 @@ Sandbox.init = function(id, cb) {
   this.receipts = {};
   this.createVM(cb);
   this.miner = setInterval(this.mineBlock.bind(this), 5000);
+  this.pauseMiner = false;
   this.logListeners = [];
   this.projectName = null;
 };
@@ -213,7 +214,11 @@ Sandbox.sendTx = util.synchronize(function(options, cb) {
   check.call(this, tx, (function(err) {
     if (err) return cb(err);
     cb(null, util.toHex(tx.getTx().hash()));
-    this.addPendingTx(tx);
+    if (options.delayed) {
+      this.addPendingTxDelayed(tx);
+    } else {
+      this.addPendingTx(tx);
+    }
   }).bind(this));
 
   function check(tx, cb) {
@@ -274,11 +279,22 @@ Sandbox.addPendingTx = function(tx) {
   this.pendingTransactions.push(tx);
   this.runPendingTx();
 };
+Sandbox.addPendingTxDelayed = function(tx) {
+  this.filters.newPendingTx(tx);
+  this.pendingTransactions.push(tx);
+};
 Sandbox.runPendingTx = function() {
-  if (this.miningBlock || this.pendingTransactions.length === 0) return;
+  if (this.pendingTransactions.length == 0) return;
+  runTxs.bind(this)([this.pendingTransactions[0]], false);
+};
+Sandbox.runAllPendingTxs = function() {
+  runTxs.bind(this)(this.pendingTransactions, true);
+};
+function runTxs(txs, runAllImmediately) {
+  if (this.miningBlock || txs.length === 0) return;
   this.miningBlock = true;
 
-  this.createNextBlock([this.pendingTransactions[0].getTx()], (function(err, block) {
+  this.createNextBlock(txs.map(tx => tx.getTx()), (function(err, block) {
     if (err) {
       this.miningBlock = false;
       return console.error(err);
@@ -293,30 +309,46 @@ Sandbox.runPendingTx = function() {
     ], (function(err, results) {
       if (!this.vm) return;
       
-      var tx = this.pendingTransactions.shift();
-      this.miningBlock = false;
-      this.runPendingTx();
       if (err) console.error(err);
       else {
-        var receipt = Object.create(Receipt)
-              .init(tx, block, results[0].receipts[0], results[0].results[0]);
-        this.receipts[util.toHex(tx.getTx().hash())] = receipt;
+        var i = 0;
+        function processTx(tx) {
+          var receipt = Object.create(Receipt)
+                .init(tx, block, results[0].receipts[i], results[0].results[i]);
+          this.receipts[util.toHex(tx.getTx().hash())] = receipt;
 
-        if (tx.contract && receipt.contractAddress) {
-          this.contracts[receipt.contractAddress] = tx.contract;
-          this.contracts[receipt.contractAddress].gasUsed = util.toHex(receipt.gasUsed);
-          this.contracts[receipt.contractAddress].data = tx.data;
+          if (tx.contract && receipt.contractAddress) {
+            this.contracts[receipt.contractAddress] = tx.contract;
+            this.contracts[receipt.contractAddress].gasUsed = util.toHex(receipt.gasUsed);
+            this.contracts[receipt.contractAddress].data = tx.data;
+          }
+
+          this.filters.newBlock(block);
+          this.newLogs(receipt.logs);
+          this.filters.newLogs(receipt.logs);
         }
-
-        this.filters.newBlock(block);
-        this.newLogs(receipt.logs);
-        this.filters.newLogs(receipt.logs);
+        if (runAllImmediately) { 
+          var txsToProcess = _.clone(this.pendingTransactions);
+          this.pendingTransactions = [];
+          this.miningBlock = false;
+          do {
+            var tx = txsToProcess.shift();
+            processTx.bind(this)(tx);
+            i++;
+          } while(txsToProcess.length > 0);
+          this.miningBlock = false;
+        } else {
+          var tx = this.pendingTransactions.shift();
+          this.miningBlock = false;
+          processTx.bind(this)(tx);
+          this.runPendingTx();
+        }
       }
     }).bind(this));
   }).bind(this));
 };
 Sandbox.mineBlock = function() {
-  if (this.miningBlock) return;
+  if (this.miningBlock || this.pauseMiner) return;
   this.miningBlock = true;
   this.createNextBlock([], (function(err, block) {
     if (err) {
@@ -327,7 +359,7 @@ Sandbox.mineBlock = function() {
       this.miningBlock = false;
       if (err) console.error(err);
       else this.filters.newBlock(block);
-      this.runPendingTx();
+      this.runAllPendingTxs();
     }).bind(this));
   }).bind(this));
 };

--- a/specs/sandbox-json-rpc.json
+++ b/specs/sandbox-json-rpc.json
@@ -1,6 +1,5 @@
 {
-  "Provides default account": [
-    {
+  "Provides default account": [ {
       "name": "sandbox_addAccounts",
       "params": [{
         "0xdedb49385ad5b94a16f236a6890cf9e0b1e30392": {
@@ -204,6 +203,18 @@
         "exception":null,
         "rlp":"0xf86580850ba43b7400832fefd89486e0497e32a8e1d79fe38ab87dc80140df5470d910801ba0f5ddc1b9b34d7f7e16cc01f6c0168e3c6e267a0a32e0049bdb451a5aeff6453ba054e0f07b8baa60ba670f85d0f1435ccd74b5dbf18901c7cb5bb3ac52380e2399"
       }
+    }
+  ],
+  "Controls the sandbox miner": [
+    {
+      "name": "sandbox_pauseMiner",
+      "params": [],
+      "result": null
+    },
+    {
+      "name": "sandbox_resumeMiner",
+      "params": [],
+      "result": null
     }
   ]
 }


### PR DESCRIPTION
The default behavior remains the same - if you add a tx, it is mined immediately.
However, if you submit a tx with the option delayed=true, it will not be mined immediately. This adds support for multiple transactions in one block.
The best way to use it is to pause the miner before that, submitting the transactions and resuming the miner.